### PR TITLE
debug: app表示メニュー　ラベル名誤りの修正

### DIFF
--- a/src/components/component/TopbarAndMenus/menuDrower/dialogs/appPreference/appTabPanel.tsx
+++ b/src/components/component/TopbarAndMenus/menuDrower/dialogs/appPreference/appTabPanel.tsx
@@ -175,7 +175,7 @@ const AppTabPanel:React.FC<tAppTabPanel> = (props) => {
                         isChecked={props.status.isDefDispCreationTree}
                         onClick={props.handler.switch.bind(null,"defDispCreationTree",undefined)}
                     >
-                        原価表
+                        生産ツリー
                     </ListItemInSwitch>
                 </List>
             </Paper>


### PR DESCRIPTION
２年も同じラベルが表示されていたことに気づかなかった不具合に気づいたのでささっと修正

## 作業前

![image](https://github.com/Helestia/moecost/assets/68133854/56a2a442-bb50-4af8-9e95-48f128469289)

## 作業後

![image](https://github.com/Helestia/moecost/assets/68133854/948cafb7-709e-4b4b-b30c-6b0a7f9ace3b)
